### PR TITLE
Refresh onfido-php after onfido-openapi-spec update (964fb43)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,9 +1,9 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "8c793a1",
-    "long_sha": "8c793a1c8307dcd92fa657edb2a1e9b184c15278",
-    "version": "v4.3.0"
+    "short_sha": "964fb43",
+    "long_sha": "964fb43a1bf211197ef7a45c230771b8ba561b3c",
+    "version": "v4.4.0"
   },
-  "release": "v8.3.0"
+  "release": "v8.4.0"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "onfido/onfido-php",
-    "version": "8.3.0",
+    "version": "8.4.0",
     "description": "The Onfido API (v3.6)",
     "keywords": [
         "openapitools",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7627009cb2d39afe87d6129923a26420",
+    "content-hash": "cb025a83af0cf56050db0c5b46bdd8e6",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -87,7 +87,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'onfido-php/8.3.0';
+    protected $userAgent = 'onfido-php/8.4.0';
 
     /**
      * Debug switch (default set to false)
@@ -404,7 +404,7 @@ class Configuration
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    The version of the OpenAPI document: v3.6' . PHP_EOL;
-        $report .= '    SDK Package Version: 8.3.0' . PHP_EOL;
+        $report .= '    SDK Package Version: 8.4.0' . PHP_EOL;
         $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
         return $report;

--- a/lib/Model/Task.php
+++ b/lib/Model/Task.php
@@ -511,7 +511,7 @@ class Task implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets output
      *
-     * @param object|null $output Output object with the fields produced by the Task execution.
+     * @param object|null $output Value field (it can be an Object, List, etc.) with the fields produced by the Task execution.
      *
      * @return self
      */

--- a/lib/Model/WebhookEventPayloadResource.php
+++ b/lib/Model/WebhookEventPayloadResource.php
@@ -714,7 +714,7 @@ class WebhookEventPayloadResource implements ModelInterface, ArrayAccess, \JsonS
     /**
      * Sets output
      *
-     * @param object|null $output Output object with the fields produced by the Task execution.
+     * @param object|null $output Value field (it can be an Object, List, etc.) with the fields produced by the Task execution.
      *
      * @return self
      */

--- a/lib/Model/WebhookEventResourceType.php
+++ b/lib/Model/WebhookEventResourceType.php
@@ -54,6 +54,10 @@ class WebhookEventResourceType
 
     public const WATCHLIST_MONITOR = 'watchlist_monitor';
 
+    public const WORKFLOW_TIMELINE_FILE = 'workflow_timeline_file';
+
+    public const WORKFLOW_RUN_EVIDENCE_FOLDER = 'workflow_run_evidence_folder';
+
     public const UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api';
 
     /**
@@ -69,6 +73,8 @@ class WebhookEventResourceType
             self::WORKFLOW_RUN,
             self::WORKFLOW_TASK,
             self::WATCHLIST_MONITOR,
+            self::WORKFLOW_TIMELINE_FILE,
+            self::WORKFLOW_RUN_EVIDENCE_FOLDER,
             self::UNKNOWN_DEFAULT_OPEN_API
         ];
     }

--- a/lib/Model/WebhookEventType.php
+++ b/lib/Model/WebhookEventType.php
@@ -76,6 +76,8 @@ class WebhookEventType
 
     public const WORKFLOW_SIGNED_EVIDENCE_FILE_CREATED = 'workflow_signed_evidence_file.created';
 
+    public const WORKFLOW_RUN_EVIDENCE_FOLDER_CREATED = 'workflow_run_evidence_folder.created';
+
     public const UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api';
 
     /**
@@ -102,6 +104,7 @@ class WebhookEventType
             self::REPORT_COMPLETED,
             self::WORKFLOW_TIMELINE_FILE_CREATED,
             self::WORKFLOW_SIGNED_EVIDENCE_FILE_CREATED,
+            self::WORKFLOW_RUN_EVIDENCE_FOLDER_CREATED,
             self::UNKNOWN_DEFAULT_OPEN_API
         ];
     }

--- a/test/StudioWebhookEventVerifierTest.php
+++ b/test/StudioWebhookEventVerifierTest.php
@@ -54,4 +54,26 @@ class StudioWebhookEventVerifierTest extends TestCase
         $this->expectException(Onfido\OnfidoInvalidSignatureError::class);
         $event = self::$webhookEventVerifier->readPayload(self::$rawEvent, $signature);
     }
+
+    public function testWebhookVerificationWithObjectInOuput(): void
+    {
+        $signature = "e3e5565647f5ccf07b2fd8ac22eab94a0a0619413d981fb768295c820523f7d7";
+
+        $rawEventFromFile = file_get_contents('test/media/studio_webhook_event_with_object_in_output.json');
+        $event = self::$webhookEventVerifier->readPayload($rawEventFromFile, $signature);
+
+        $this->assertNotNull($event->getPayload()->getResource()->getOutput()['properties']);
+    }
+
+
+    public function testWebhookVerificationWithListInOuput(): void
+    {
+        $signature = "f3a5170acfcecf8c1bf6d9cb9995c0d9dec941af83056a721530f8de7af2c293";
+
+        $rawEventFromFile = file_get_contents('test/media/studio_webhook_event_with_list_in_output.json');
+        $event = self::$webhookEventVerifier->readPayload($rawEventFromFile, $signature);
+
+        $this->assertNotNull($event->getPayload()->getResource()->getOutput()[0]);
+    }
+
 }

--- a/test/media/studio_webhook_event_with_list_in_output.json
+++ b/test/media/studio_webhook_event_with_list_in_output.json
@@ -1,0 +1,31 @@
+{
+  "payload": {
+    "resource_type": "workflow_task",
+    "action": "workflow_task.completed",
+    "object": {
+      "id": "document_photo_5c229",
+      "task_spec_id": "document_photo_5c229",
+      "task_def_id": "upload_document_photo",
+      "workflow_run_id": "b48fdff9-66a1-405d-9912-54780799bd68",
+      "status": "completed",
+      "completed_at_iso8601": "2024-12-18T18:13:10Z",
+      "href": "https://api.eu.onfido.com/v3.6/workflow_runs/b48fdff9-66a1-405d-9912-54780799bd68/tasks/document_photo_5c229"
+    },
+    "resource": {
+      "updated_at": "2024-12-18T18:13:10Z",
+      "output": [
+        {
+          "type": "document_photo",
+          "id": "7af75a3a-ba34-4aa5-9e3e-096c9f56256b",
+          "checksum_sha256": "hiwV2PLmeQZzeySPGGwVL48sxVXcyfpXy9LDl1u3lWU="
+        }
+      ],
+      "created_at": "2024-12-18T18:12:44Z",
+      "task_def_id": "upload_document_photo",
+      "input": {},
+      "workflow_run_id": "b48fdff9-66a1-405d-9912-54780799bd68",
+      "task_def_version": null,
+      "id": "document_photo_5c229"
+    }
+  }
+}

--- a/test/media/studio_webhook_event_with_object_in_output.json
+++ b/test/media/studio_webhook_event_with_object_in_output.json
@@ -1,0 +1,264 @@
+{
+  "payload": {
+    "resource_type": "workflow_task",
+    "action": "workflow_task.completed",
+    "object": {
+      "id": "document_check_75329",
+      "task_spec_id": "document_check_75329",
+      "task_def_id": "document_check",
+      "workflow_run_id": "b48fdff9-66a1-405d-9912-54780799bd68",
+      "status": "completed",
+      "completed_at_iso8601": "2024-12-18T18:13:13Z",
+      "href": "https://api.eu.onfido.com/v3.6/workflow_runs/b48fdff9-66a1-405d-9912-54780799bd68/tasks/document_check_75329"
+    },
+    "resource": {
+      "task_def_version": null,
+      "task_def_id": "document_check",
+      "updated_at": "2024-12-18T18:13:13Z",
+      "id": "document_check_75329",
+      "output": {
+        "status": "complete",
+        "result": "clear",
+        "sub_result": "clear",
+        "uuid": "95c8cc09-db72-42ff-85ef-ee6c82020a24",
+        "properties": {
+          "date_of_birth": "1990-01-01",
+          "date_of_expiry": "2031-05-28",
+          "document_numbers": [
+            {
+              "type": "document_number",
+              "value": "999999999"
+            }
+          ],
+          "document_type": "passport",
+          "first_name": "Jane",
+          "issuing_country": "GBR",
+          "last_name": "Doe",
+          "document_number": "999999999"
+        },
+        "breakdown": {
+          "data_validation": {
+            "result": "clear",
+            "breakdown": {
+              "mrz": {
+                "result": "clear",
+                "properties": {}
+              },
+              "expiry_date": {
+                "result": "clear",
+                "properties": {}
+              },
+              "document_expiration": {
+                "result": "clear",
+                "properties": {}
+              },
+              "document_numbers": {
+                "result": "clear",
+                "properties": {}
+              },
+              "date_of_birth": {
+                "result": "clear",
+                "properties": {}
+              },
+              "gender": {
+                "result": "clear",
+                "properties": {}
+              }
+            }
+          },
+          "visual_authenticity": {
+            "result": "clear",
+            "breakdown": {
+              "face_detection": {
+                "result": "clear",
+                "properties": {}
+              },
+              "other": {
+                "result": "clear",
+                "properties": {}
+              },
+              "digital_tampering": {
+                "result": "clear",
+                "properties": {}
+              },
+              "original_document_present": {
+                "result": "clear",
+                "properties": {}
+              },
+              "security_features": {
+                "result": "clear",
+                "properties": {}
+              },
+              "template": {
+                "result": "clear",
+                "properties": {}
+              },
+              "picture_face_integrity": {
+                "result": "clear",
+                "properties": {}
+              },
+              "fonts": {
+                "result": "clear",
+                "properties": {}
+              }
+            }
+          },
+          "compromised_document": {
+            "result": "clear",
+            "breakdown": {
+              "repeat_attempts": {
+                "result": "clear",
+                "properties": {}
+              },
+              "document_database": {
+                "result": "clear",
+                "properties": {}
+              }
+            }
+          },
+          "data_consistency": {
+            "result": "clear",
+            "breakdown": {
+              "nationality": {
+                "result": "clear",
+                "properties": {}
+              },
+              "last_name": {
+                "result": "clear",
+                "properties": {}
+              },
+              "first_name": {
+                "result": "clear",
+                "properties": {}
+              },
+              "multiple_data_sources_present": {
+                "result": "clear",
+                "properties": {}
+              },
+              "gender": {
+                "result": "clear",
+                "properties": {}
+              },
+              "date_of_birth": {
+                "result": "clear",
+                "properties": {}
+              },
+              "document_type": {
+                "result": "clear",
+                "properties": {}
+              },
+              "issuing_country": {
+                "result": "clear",
+                "properties": {}
+              },
+              "document_numbers": {
+                "result": "clear",
+                "properties": {}
+              },
+              "date_of_expiry": {
+                "result": "clear",
+                "properties": {}
+              }
+            }
+          },
+          "data_comparison": {
+            "result": "clear",
+            "breakdown": {
+              "date_of_birth": {
+                "result": "clear",
+                "properties": {}
+              },
+              "first_name": {
+                "result": "clear",
+                "properties": {}
+              },
+              "document_numbers": {
+                "result": "clear",
+                "properties": {}
+              },
+              "document_type": {
+                "result": "clear",
+                "properties": {}
+              },
+              "last_name": {
+                "result": "clear",
+                "properties": {}
+              },
+              "date_of_expiry": {
+                "result": "clear",
+                "properties": {}
+              },
+              "gender": {
+                "result": "clear",
+                "properties": {}
+              },
+              "issuing_country": {
+                "result": "clear",
+                "properties": {}
+              }
+            }
+          },
+          "image_integrity": {
+            "result": "clear",
+            "breakdown": {
+              "colour_picture": {
+                "result": "clear",
+                "properties": {}
+              },
+              "supported_document": {
+                "result": "clear",
+                "properties": {}
+              },
+              "conclusive_document_quality": {
+                "result": "clear",
+                "properties": {}
+              },
+              "image_quality": {
+                "result": "clear",
+                "properties": {}
+              }
+            }
+          },
+          "police_record": {
+            "result": "clear",
+            "breakdown": {
+              "document_has_not_been_recorded_as_lost,_stolen_or_compromised": {
+                "result": "clear",
+                "properties": {}
+              }
+            }
+          },
+          "age_validation": {
+            "result": "clear",
+            "breakdown": {
+              "minimum_accepted_age": {
+                "result": "clear",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "repeat_attempts": {
+          "report_id": "00000000-0000-0000-0000-000000000000",
+          "repeat_attempts": [],
+          "attempts_count": 1,
+          "attempts_clear_rate": 0,
+          "unique_mismatches_count": 0
+        }
+      },
+      "workflow_run_id": "b48fdff9-66a1-405d-9912-54780799bd68",
+      "input": {
+        "document_ids": [
+          {
+            "checksum_sha256": "hiwV2PLmeQZzeySPGGwVL48sxVXcyfpXy9LDl1u3lWU=",
+            "id": "7af75a3a-ba34-4aa5-9e3e-096c9f56256b",
+            "type": "document_photo"
+          }
+        ],
+        "first_name": "Jane",
+        "last_name": "Doe"
+      },
+      "created_at": "2024-12-18T18:13:11Z"
+    }
+  }
+}


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@964fb43a1bf211197ef7a45c230771b8ba561b3c (included)

Additional changes:
  - [Update tests after library refresh](https://github.com/onfido/onfido-php/pull/70/commits/e7b176d5d7a3663a881aa512225b3a43e71056f5)