### PR TITLE
Refresh onfido-php after onfido-openapi-spec update (54ce45f)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,9 +1,9 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "964fb43",
-    "long_sha": "964fb43a1bf211197ef7a45c230771b8ba561b3c",
-    "version": "v4.4.0"
+    "short_sha": "54ce45f",
+    "long_sha": "54ce45f2138f044cc5cb40f6904dc7bc1a675be6",
+    "version": "v4.5.0"
   },
-  "release": "v8.4.0"
+  "release": "v8.5.0"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "onfido/onfido-php",
-    "version": "8.4.0",
+    "version": "8.5.0",
     "description": "The Onfido API (v3.6)",
     "keywords": [
         "openapitools",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb025a83af0cf56050db0c5b46bdd8e6",
+    "content-hash": "902ccc0c901360feaf96721a6d554ff2",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/lib/Api/DefaultApi.php
+++ b/lib/Api/DefaultApi.php
@@ -113,6 +113,9 @@ class DefaultApi
         'downloadDocumentVideo' => [
             'application/json',
         ],
+        'downloadEvidenceFolder' => [
+            'application/json',
+        ],
         'downloadIdPhoto' => [
             'application/json',
         ],
@@ -4574,6 +4577,354 @@ class DefaultApi
 
         $headers = $this->headerSelector->selectHeaders(
             ['*/*', 'application/json', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+        // this endpoint requires API key authentication
+        $apiKey = $this->config->getApiKeyWithPrefix('Authorization');
+        if ($apiKey !== null) {
+            $headers['Authorization'] = $apiKey;
+        }
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation downloadEvidenceFolder
+     *
+     * Retrieve Workflow Run Evidence Folder
+     *
+     * @param  string $workflow_run_id Workflow Run ID (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['downloadEvidenceFolder'] to see the possible values for this operation
+     *
+     * @throws \Onfido\ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws \InvalidArgumentException
+     * @return |\SplFileObject|\Onfido\Model\Error
+     */
+    public function downloadEvidenceFolder($workflow_run_id, string $contentType = self::contentTypes['downloadEvidenceFolder'][0])
+    {
+        list($response) = $this->downloadEvidenceFolderWithHttpInfo($workflow_run_id, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation downloadEvidenceFolderWithHttpInfo
+     *
+     * Retrieve Workflow Run Evidence Folder
+     *
+     * @param  string $workflow_run_id Workflow Run ID (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['downloadEvidenceFolder'] to see the possible values for this operation
+     *
+     * @throws \Onfido\ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws \InvalidArgumentException
+     * @return array of |\SplFileObject|\Onfido\Model\Error, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function downloadEvidenceFolderWithHttpInfo($workflow_run_id, string $contentType = self::contentTypes['downloadEvidenceFolder'][0])
+    {
+        $request = $this->downloadEvidenceFolderRequest($workflow_run_id, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+
+            switch($statusCode) {
+                case 200:
+                    if ('\SplFileObject' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\SplFileObject' !== 'string') {
+                            try {
+                                $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                            } catch (\JsonException $exception) {
+                                throw new ApiException(
+                                    sprintf(
+                                        'Error JSON decoding server response (%s)',
+                                        $request->getUri()
+                                    ),
+                                    $statusCode,
+                                    $response->getHeaders(),
+                                    $content
+                                );
+                            }
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SplFileObject', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                default:
+                    if ('\Onfido\Model\Error' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\Onfido\Model\Error' !== 'string') {
+                            try {
+                                $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                            } catch (\JsonException $exception) {
+                                throw new ApiException(
+                                    sprintf(
+                                        'Error JSON decoding server response (%s)',
+                                        $request->getUri()
+                                    ),
+                                    $statusCode,
+                                    $response->getHeaders(),
+                                    $content
+                                );
+                            }
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\Onfido\Model\Error', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            $returnType = '\SplFileObject';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    try {
+                        $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                    } catch (\JsonException $exception) {
+                        throw new ApiException(
+                            sprintf(
+                                'Error JSON decoding server response (%s)',
+                                $request->getUri()
+                            ),
+                            $statusCode,
+                            $response->getHeaders(),
+                            $content
+                        );
+                    }
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SplFileObject',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                default:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\Onfido\Model\Error',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation downloadEvidenceFolderAsync
+     *
+     * Retrieve Workflow Run Evidence Folder
+     *
+     * @param  string $workflow_run_id Workflow Run ID (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['downloadEvidenceFolder'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function downloadEvidenceFolderAsync($workflow_run_id, string $contentType = self::contentTypes['downloadEvidenceFolder'][0])
+    {
+        return $this->downloadEvidenceFolderAsyncWithHttpInfo($workflow_run_id, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation downloadEvidenceFolderAsyncWithHttpInfo
+     *
+     * Retrieve Workflow Run Evidence Folder
+     *
+     * @param  string $workflow_run_id Workflow Run ID (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['downloadEvidenceFolder'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function downloadEvidenceFolderAsyncWithHttpInfo($workflow_run_id, string $contentType = self::contentTypes['downloadEvidenceFolder'][0])
+    {
+        $returnType = '\SplFileObject';
+        $request = $this->downloadEvidenceFolderRequest($workflow_run_id, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'downloadEvidenceFolder'
+     *
+     * @param  string $workflow_run_id Workflow Run ID (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['downloadEvidenceFolder'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    public function downloadEvidenceFolderRequest($workflow_run_id, string $contentType = self::contentTypes['downloadEvidenceFolder'][0])
+    {
+
+        // verify the required parameter 'workflow_run_id' is set
+        if ($workflow_run_id === null || (is_array($workflow_run_id) && count($workflow_run_id) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $workflow_run_id when calling downloadEvidenceFolder'
+            );
+        }
+
+
+        $resourcePath = '/workflow_runs/{workflow_run_id}/evidence_folder';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+
+        // path params
+        if ($workflow_run_id !== null) {
+            $resourcePath = str_replace(
+                '{' . 'workflow_run_id' . '}',
+                ObjectSerializer::toPathValue($workflow_run_id),
+                $resourcePath
+            );
+        }
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/zip', 'application/json', ],
             $contentType,
             $multipart
         );

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -87,7 +87,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'onfido-php/8.4.0';
+    protected $userAgent = 'onfido-php/8.5.0';
 
     /**
      * Debug switch (default set to false)
@@ -404,7 +404,7 @@ class Configuration
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    The version of the OpenAPI document: v3.6' . PHP_EOL;
-        $report .= '    SDK Package Version: 8.4.0' . PHP_EOL;
+        $report .= '    SDK Package Version: 8.5.0' . PHP_EOL;
         $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
         return $report;

--- a/test/Resource/WorkflowRunsTest.php
+++ b/test/Resource/WorkflowRunsTest.php
@@ -110,6 +110,24 @@ class WorkflowRunsTest extends OnfidoTestCase
 
         $this->assertGreaterThan(0, $file->getSize());
     }
+
+    public function testDownloadEvidenceFolder(): void
+    {
+        $workflowId = '221f9d24-cf72-4762-ac4a-01bf3ccc09dd';
+        $workflowRunId = $this->createWorkflowRun(null, $this->applicantId, $workflowId)->getId();
+        $findWorkflowRunFn = function($workflowRunId) {
+          return self::$onfido->findWorkflowRun($workflowRunId);
+        };
+        $this->repeatRequestUntilStatusChanges(
+          $findWorkflowRunFn,
+          [$workflowRunId],
+          WorkflowRunStatus::APPROVED
+        )->getOutput();
+
+        $file = self::$onfido->downloadEvidenceFolder($workflowRunId);
+
+        $this->assertGreaterThan(0, $file->getSize());
+    }
 }
 
 ?>


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@54ce45f2138f044cc5cb40f6904dc7bc1a675be6 (included)

Additional changes:
  - [Add downloadEvidenceFolder test](https://github.com/onfido/onfido-php/pull/71/commits/2b65e84a77f3897043645b2fa9dbb70769e783c3)