### PR TITLE
test: wait for evidence folder to be available

### DIFF
--- a/test/OnfidoTestCase.php
+++ b/test/OnfidoTestCase.php
@@ -176,7 +176,7 @@ abstract class OnfidoTestCase extends TestCase
         callable $function,
         array $params,
         string $status,
-        $maxRetries = 10,
+        $maxRetries = 15,
         $sleepTime = 1
     )
     {
@@ -199,7 +199,7 @@ abstract class OnfidoTestCase extends TestCase
     protected function repeatRequestUntilTaskOutputChanges(
         callable $function,
         array $params,
-        $maxRetries = 10,
+        $maxRetries = 15,
         $sleepTime = 1
     )
     {
@@ -222,7 +222,7 @@ abstract class OnfidoTestCase extends TestCase
     protected function repeatRequestUntilHttpCodeChanges(
         callable $function,
         array $params,
-        $maxRetries = 10,
+        $maxRetries = 15,
         $sleepTime = 1
     )
     {

--- a/test/Resource/ReportsTest.php
+++ b/test/Resource/ReportsTest.php
@@ -48,12 +48,21 @@ class ReportsTest extends OnfidoTestCase
 
     public function testFindReport(): void
     {
+        $findReportFn = function($reportId) {
+            return self::$onfido->findReport($reportId);
+        };
+
+        $getDocumentReport = $this->repeatRequestUntilStatusChanges(
+            $findReportFn,
+            [$this->documentReportId],
+            ReportStatus::COMPLETE
+        );
         $getDocumentReport = self::$onfido->findReport($this->documentReportId);
         $getIdentityReport = self::$onfido->findReport($this->identityReportId);
 
         $this->assertSame($this->documentReportId, $getDocumentReport->getId());
         $this->assertSame(ReportName::DOCUMENT, $getDocumentReport->getName());
-        $this->assertSame(ReportStatus::AWAITING_DATA, $getDocumentReport->getStatus());
+        $this->assertSame(ReportStatus::COMPLETE, $getDocumentReport->getStatus());
 
         $this->assertSame($this->identityReportId, $getIdentityReport->getId());
         $this->assertSame(ReportName::IDENTITY_ENHANCED, $getIdentityReport->getName());

--- a/test/Resource/WorkflowRunsTest.php
+++ b/test/Resource/WorkflowRunsTest.php
@@ -124,7 +124,14 @@ class WorkflowRunsTest extends OnfidoTestCase
           WorkflowRunStatus::APPROVED
         )->getOutput();
 
-        $file = self::$onfido->downloadEvidenceFolder($workflowRunId);
+        $getEvidenceFolderFn = function($workflowRunId) {
+          return self::$onfido->downloadEvidenceFolder($workflowRunId);
+        };
+
+        $file = $this->repeatRequestUntilHttpCodeChanges(
+          $getEvidenceFolderFn,
+          [$workflowRunId]
+        );
 
         $this->assertGreaterThan(0, $file->getSize());
     }


### PR DESCRIPTION
Evidence folder needs to be available before it can be downloaded. Fix the test by retrying the request until we no longer receive 404.

I also did some extra changes (increasing number of retries) to reduce test flakiness.