### PR TITLE
Fix CHANGELOG.md and improve CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -36,7 +36,8 @@ jobs:
           php_version: ${{ matrix.php-version }}
       - name: Test with phpunit
         if: ${{ matrix.php-version == '8.3' &&
-                github.repository_owner == 'onfido' }}
+          github.repository_owner == 'onfido' &&
+          (github.event_name == 'pull_request' || github.event_name == 'release') }}
         run: |
           vendor/bin/phpunit
         env:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,6 +21,9 @@ on:
   schedule:
     - cron: "0 15 * * 0"   # Every Sunday, 3 hours after midday
 
+permissions:
+  contents: read
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
@@ -52,6 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration-tests
     environment: delivery
+    permissions:
+      contents: write
     if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up PHP ${{ matrix.php-version }}
-        uses: php-actions/composer@v6
+        uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
         with:
           php_version: ${{ matrix.php-version }}
       - name: Test with phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 - Release based on Onfido OpenAPI spec version [v5.4.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v5.4.0):
   - [ENT-26] Add AES document download endpoint
+- [ENT-26] Add AES documents test
 
 ## v9.3.0 11th July 2025
 
-- Release based on Onfido OpenAPI spec version [v5.3.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v5.3.0):
 - Release based on Onfido OpenAPI spec version [v5.3.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v5.3.0):
   - [DEXTV2-9494] Add manual_transmission_restriction to document with driver verification report
 


### PR DESCRIPTION
Fix CHANGELOG.md and improve CI to not run tests when commit is not coming from a PR (i.e. CHANGELOG update performed by the CI).

Take the opportunity for fixing a few security vulnerabilities:

- https://github.com/onfido/onfido-php/security/code-scanning/1
- https://github.com/onfido/onfido-php/security/code-scanning/2
- https://github.com/onfido/onfido-php/security/code-scanning/3
